### PR TITLE
Fixed communication with SWANK running under ClozureCL

### DIFF
--- a/src/swank-protocol.lisp
+++ b/src/swank-protocol.lisp
@@ -166,7 +166,8 @@ to check if input is available."
 (defmacro with-swank-syntax (() &body body)
   `(with-standard-io-syntax
      (let ((*package* (find-package :swank-io-package))
-           (*print-case* :downcase))
+           (*print-case* :downcase)
+           (*print-readably* nil))
        ,@body)))
 
 (defun emacs-rex (connection form)


### PR DESCRIPTION
This patch fixes:

```
Reader error on #<STRING-INPUT-STREAM  :CLOSED #x30200139FB9D>:
  reader macro #A used without a rank integer
```
error.

Here is what SWANK returned as a reply to the `(+ 1 3)` evaluation:

```lisp
(:READER-ERROR
    "(:emacs-rex (swank-repl:listener-eval #A((7) common-lisp:base-char . \"(+ 1 2)\")) \"COMMON-LISP-USER\" :repl-thread 5)
"
    "Reader error on #<STRING-INPUT-STREAM  :CLOSED #x30200139FB9D>:
reader macro #A used without a rank integer"
```

I discovered this problem when tried REPL example from Lime.

The similar patch was tested on Lem and worked there:
https://github.com/cxxxr/lem/pull/471/files