### PR TITLE
Allow to send/receive swank messages containing UTF-8 characters.

### DIFF
--- a/swank-protocol.asd
+++ b/swank-protocol.asd
@@ -7,7 +7,8 @@
   :bug-tracker "https://github.com/eudoxia0/swank-protocol/issues"
   :source-control (:git "git@github.com:eudoxia0/swank-protocol.git")
   :depends-on (:usocket
-               :swank)
+               :swank
+               (:feature (:not (:or :sbcl :allegro :ccl :clisp)) :babel))
   :components ((:module "src"
                 :serial t
                 :components


### PR DESCRIPTION
This allows for the exchange of Swank messages containing UTF-8 characters.

Since the length as a string and the byte length are different, sending a UTF-8 message will cause the Swank server to stop.

Example: `(swank-protocol:request-listener-eval connection "#\\あ")`